### PR TITLE
Started reordering Subvector template parameters

### DIFF
--- a/cc/math/tests/vector2_test.cc
+++ b/cc/math/tests/vector2_test.cc
@@ -54,13 +54,28 @@ TEST(Vector2Test, Normal) {
 TEST(Vector2Test, Subvector) {
   VectorOwned<double, 3> v3({1.0, 2.0, 3.0});    
 
-  VectorOwned<double, 2> v2 = Subvector<double, 3, 2>(v3, 1);
+  VectorOwned<double, 2> v2 = Subvector<2, double, 3>(v3, 1);
 
   const VectorOwned<double, 2> expected_v2({2.0, 3.0});
   EXPECT_EQ(v2, expected_v2);
 
   v2 *= 10.0;
-  Subvector<double, 3, 2>(v3, 1) = v2;
+  Subvector<2, double, 3>(v3, 1) = v2;
+
+  const VectorOwned<double, 3> expected_v3({1.0, 20.0, 30.0});
+  EXPECT_EQ(v3, expected_v3);  
+}
+  
+TEST(Vector2Test, SubvectorAutoTemplateTypes) {
+  VectorOwned<double, 3> v3({1.0, 2.0, 3.0});    
+
+  VectorOwned<double, 2> v2 = Subvector<2>(v3, 1);
+
+  const VectorOwned<double, 2> expected_v2({2.0, 3.0});
+  EXPECT_EQ(v2, expected_v2);
+
+  v2 *= 10.0;
+  Subvector<2>(v3, 1) = v2;
 
   const VectorOwned<double, 3> expected_v3({1.0, 20.0, 30.0});
   EXPECT_EQ(v3, expected_v3);  

--- a/cc/math/vector_impl.h
+++ b/cc/math/vector_impl.h
@@ -17,15 +17,31 @@ using VectorOwned = Eigen::Matrix<ScalarT, dim, 1>;
 template <class ScalarT, int dim>
 using ConstVector = Eigen::Matrix<ScalarT, dim, 1>;  
 
+// Read only subvector view.
+// Template parameters:
+//   subdim - Subvector dimensions.
+//   ScalarT - Scalar value type.
+//   dim - Full vector dimensions.
+// Parameters:
+//   v - Full vector.
+//   begin_row - First row to appear in the subvector.
 // Returns a read only view of a subvector of rows in [begin_row, begin_row + subdim).
-template<class ScalarT, int dim, int subdim>
+template<int subdim, class ScalarT, int dim>
 const auto Subvector(
     const ConstVector<ScalarT, dim>& v, int begin_row) {
   return v.template block<subdim, 1>(begin_row, 0);
 }
 
+// Mutable subvector view.
+// Template parameters:
+//   subdim - Subvector dimensions.
+//   ScalarT - Scalar value type.
+//   dim - Full vector dimensions.
+// Parameters:
+//   v - Full vector.
+//   begin_row - First row to appear in the subvector.
 // Returns a mutable view of a subvector of rows in [begin_row, begin_row + subdim).
-template<class ScalarT, int dim, int subdim>
+template<int subdim, class ScalarT, int dim>
 auto Subvector(Vector<ScalarT, dim>& v, int begin_row) {
   return v.template block<subdim, 1>(begin_row, 0);
 }


### PR DESCRIPTION
Reorders the Subvector template parameters so the full vector <ScalarT, dim> can be automatically filled by the compiler.